### PR TITLE
Set Ruby version, start server on start-up, enable all the prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,9 @@
 image: jelaniwoods/appdev2021-base-rails-hotfix
 tasks:
-  - command: bundle install
+  - before: rvm install 2.7.3
+  - before: bundle update --bundler  
   - init: bin/setup
+  - command: bin/server
 ports:
   - port: 3000
     onOpen: open-preview

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,9 @@
 image: jelaniwoods/appdev2021-base-rails-hotfix
 tasks:
-  - before: rvm install 2.7.3
-  - before: bundle update --bundler  
-  - init: bin/setup
-  - command: bin/server
+  - name: start server
+    before: rvm install 2.7.3 && bundle update --bundler  
+    init: bin/setup
+    command: bin/server
 ports:
   - port: 3000
     onOpen: open-preview
@@ -14,3 +14,20 @@ vscode:
     - shd101wyy.markdown-preview-enhanced
     - wingrunr21.vscode-ruby
     - vortizhe.simple-ruby-erb
+
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true


### PR DESCRIPTION
Hi @raghubetina , 

I am hoping this may be an okay workaround for you and the students who are having [trouble in this community thread](https://community.gitpod.io/t/unable-to-open-workspaces-that-use-custom-docker-image/5707/13)? I did a couple things to help in this PR.

1. [Upgrade Ruby to a version that works with this repo](https://github.com/kylos101/base-rails/blob/master/.gitpod.yml#L4-L6).
   * This should unblock users who cannot run `bin/server` due to the ruby version mismatch.
2. [Enabled Gitpod prebuilds](https://github.com/kylos101/base-rails/blob/master/.gitpod.yml#L18-L33). 
   * This should make it so that workspaces [prebuild](https://www.gitpod.io/docs/prebuilds), which should save time when folks are opening new Gitpod's from new branches, PRs, and after code has been pushed.

Caveat: I've never used Ruby before, and could use your help in reviewing this PR. Should we update the `gemfile.lock` from `1.17.3` to `2.1.4`?

Let me know what you think?

<a href="https://gitpod.io/#https://github.com/appdev-projects/base-rails/pull/18"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

