### PR TITLE
Enable default support for GitHub pages

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,12 @@ module FinalProject
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    Rails.application.config.middleware.insert_after(
+      ActionDispatch::Static,
+      ActionDispatch::Static,
+      Rails.root.join("docs").to_s,
+      index: config.public_file_server.index_name, headers: config.public_file_server.headers || {})
+    )
   end
 end


### PR DESCRIPTION
- GitHub Pages only allows for serving files from `/` or `/docs`.
- We want students to be able to preview their work with `bin/server`.
- This change configures Rails to look for static files in both `public/` and `docs/`.
- Students can work in `docs/`, preview with `bin/server`, and deploy with `git push`.